### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -1,4 +1,6 @@
 name: Self-Hosted Runner Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Ruh-Al-Tarikh/Initial-Repo/security/code-scanning/2](https://github.com/Ruh-Al-Tarikh/Initial-Repo/security/code-scanning/2)

In general, the fix is to define an explicit `permissions` block specifying the minimal required permissions for `GITHUB_TOKEN`. Since this workflow only runs a shell command that prints a message and does not require any repository write access (or even read access to contents/packages), we can safely limit the token to `contents: read` at the workflow level. This documents the intended minimal privilege and prevents accidental elevation if repository defaults change.

The best minimal, non-breaking change is to add a root-level `permissions` section just below the `name` key in `.github/workflows/self-hosted.yml`. This will apply to all jobs in the workflow (there is only one job, `test`) without modifying any job logic. No imports, libraries, or additional methods are needed; this is purely a YAML configuration change.

Concretely:
- Edit `.github/workflows/self-hosted.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between line 1 (`name: Self-Hosted Runner Test`) and line 3 (`on:`).  
This explicitly constrains `GITHUB_TOKEN` and resolves the CodeQL warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
